### PR TITLE
Initial bot boilerplate

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python main.py

--- a/cogs/wow.py
+++ b/cogs/wow.py
@@ -1,0 +1,81 @@
+import aiohttp
+import io
+import os
+
+from aiowowapi import WowApi
+from discord import File
+from discord.ext import commands
+from discord.ext.commands import Cog, Bot, Context
+
+
+# These also need to exist in the environment variables for Railway, or we 
+# can't connect to the WoW API.
+BNET_CLIENT_ID = os.environ["BNET_CLIENT_ID"]
+BNET_CLIENT_SECRET = os.environ["BNET_CLIENT_SECRET"]
+
+
+class Wow(Cog):
+    """Commands that leverage the WoW API."""
+
+    def __init__(self, bot: Bot):
+        """Initialize this cog with the Bot instance."""
+        self.bot = bot
+
+    async def _get_image_from_url(self, image_url: str):
+        """Use aiohttp to download a file, and return the IO stream for this file."""
+        async with aiohttp.ClientSession() as session:
+            async with session.get(image_url) as response:
+                return io.BytesIO(await response.read())
+
+    async def _send_image(self, ctx: Context, image_path: str = None, image_url: str = None, image: io.BytesIO = None):
+        """Send an image to the channel."""
+        if not any([image, image_url, image_path]):
+            return await ctx.send("No image provided.")
+        elif sum([bool(image), bool(image_url), bool(image_path)]) > 1:
+            return await ctx.send("Please only provide one image as input.")
+
+        if image_url:
+            image = await self._get_image_from_url(image_url)
+
+        if image_path:
+            image = image_path
+        
+        await ctx.send(file=File(image, "super_cool_image_you_guys.png"))
+
+    async def _get_image(self, player_name: str, image_type: str, realm: str, region: str = "eu"):
+        """Get a certain player image."""
+        async with WowApi(BNET_CLIENT_ID, BNET_CLIENT_SECRET, region, request_debugging=True) as Client:
+            images = await Client.Retail.Profile.get_character_media_summary(realm, player_name.lower())
+
+            if image_type == "avatar":
+                return images["assets"][0]["value"]
+            elif image_type == "inset":
+                return images["assets"][1]["value"]
+            elif image_type == "main":
+                return images["assets"][2]["value"]
+            elif image_type == "main-raw":
+                return images["assets"][3]["value"]
+            
+    async def _get_race(self, player_name: str, realm: str, region: str = "eu"):
+        """Get the player race and gender, e.g. Male Dark Iron Dwarf"""
+        async with WowApi(BNET_CLIENT_ID, BNET_CLIENT_SECRET, region, request_debugging=True) as Client:
+            profile = await Client.Retail.Profile.get_character_profile_summary(realm, player_name.lower())
+            race = profile["race"]["name"]
+            gender = profile["gender"]["name"]
+
+            return f"{gender} {race}"
+
+    @commands.command()
+    async def show_character(self, ctx: Context, player: str, realm: str, image_type: str = "main", region: str = "eu"):
+        """Show an image of a specific WoW character."""
+        image = await self._get_image(player, image_type, realm, region)
+        await self._send_image(ctx, image_url=image)
+
+
+
+async def setup(bot: Bot) -> None:
+    """
+    This function is called automatically when this cog is loaded by the bot.
+    It's only purpose is to load the cog above, and to pass the Bot instance into it.
+    """
+    await bot.add_cog(Wow(bot))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,52 @@
+import asyncio
+import logging
+import sys
+import os
+
+from discord import Intents, Game, AllowedMentions
+from discord.ext import commands
+
+# This token must exist in the environment variables for Railway.
+DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
+
+# Set up logging so we will see logs in the console
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+root.addHandler(handler)
+
+# This is how we tell Discord that we want certain data streams,
+# in this case, we want to hear events related to message content
+# and to member updates (e.g. when someone joins or leaves a server).
+intents = Intents.default()
+intents.members = True
+intents.message_content = True
+
+# Initialize the bot with various configuration options
+bot = commands.Bot(
+    command_prefix='!', 
+    intents=intents,
+    activity=Game(name="stupid"),  # "Playing stupid"
+    case_insensitive=True,
+    max_messages=10_000,
+    allowed_mentions=AllowedMentions(everyone=False, roles=False, users=True),  # Never let the bot mention @everyone or @roles
+)
+
+async def load_extensions():
+    """Load all the extensions in the /cogs folder."""
+    for filename in os.listdir("./cogs"):
+        if filename.endswith(".py"):
+
+            # cut off the .py from the file name
+            await bot.load_extension(f"cogs.{filename[:-3]}")
+
+# Run the bot!
+async def main():
+    async with bot:
+        await load_extensions()
+        await bot.start(DISCORD_TOKEN)
+
+asyncio.run(main())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,160 @@
+[[package]]
+name = "aiohttp"
+version = "3.8.4"
+description = "Async http client/server framework (asyncio)"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+aiosignal = ">=1.1.2"
+async-timeout = ">=4.0.0a3,<5.0"
+attrs = ">=17.3.0"
+charset-normalizer = ">=2.0,<4.0"
+frozenlist = ">=1.1.1"
+multidict = ">=4.5,<7.0"
+yarl = ">=1.0,<2.0"
+
+[package.extras]
+speedups = ["aiodns", "brotli", "cchardet"]
+
+[[package]]
+name = "aiosignal"
+version = "1.3.1"
+description = "aiosignal: a list of registered asynchronous callbacks"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+frozenlist = ">=1.1.0"
+
+[[package]]
+name = "aiowowapi"
+version = "2.1.4"
+description = "An asynchronous Python wrapper for the World of Warcraft APIs."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+aiohttp = ">=3.8.0"
+
+[package.extras]
+docs = ["sphinx (>=4.1.2)", "sphinx-rtd-theme (>=1.0.0)"]
+testing = ["pytest (>=6.2.4)", "pytest-asyncio (>=0.15.1)", "flake8 (>=5.0.4)", "mypy (>=0.975)"]
+
+[[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "attrs"
+version = "23.1.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+cov = ["attrs", "coverage[toml] (>=5.3)"]
+dev = ["attrs", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs", "zope-interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest-mypy-plugins", "pytest-xdist", "pytest (>=4.3.0)"]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.1.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[[package]]
+name = "discord.py"
+version = "2.1.0"
+description = "A Python wrapper for the Discord API"
+category = "main"
+optional = false
+python-versions = ">=3.8.0"
+
+[package.dependencies]
+aiohttp = ">=3.7.4,<4"
+
+[package.extras]
+docs = ["sphinx (==4.4.0)", "sphinxcontrib-trio (==1.1.2)", "sphinxcontrib-websupport", "typing-extensions (>=4.3,<5)"]
+speed = ["orjson (>=3.5.4)", "aiodns (>=1.1)", "brotli", "cchardet (==2.1.7)"]
+test = ["coverage", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "typing-extensions (>=4.3,<5)"]
+voice = ["PyNaCl (>=1.3.0,<1.6)"]
+
+[[package]]
+name = "frozenlist"
+version = "1.3.3"
+description = "A list-like structure which implements collections.abc.MutableSequence"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "idna"
+version = "3.4"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "multidict"
+version = "6.0.4"
+description = "multidict implementation"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pillow"
+version = "9.5.0"
+description = "Python Imaging Library (Fork)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-removed-in", "sphinxext-opengraph"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "yarl"
+version = "1.9.2"
+description = "Yet another URL library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "92848c2159905a3faa9c28396d3aec076019628c7535fdcf1f5d02bcf3b80af8"
+
+[metadata.files]
+aiohttp = []
+aiosignal = []
+aiowowapi = []
+async-timeout = []
+attrs = []
+charset-normalizer = []
+"discord.py" = []
+frozenlist = []
+idna = []
+multidict = []
+pillow = []
+yarl = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "frostwolf"
+version = "0.1.0"
+description = "A community bot for the No Pressure community"
+authors = ["Lemonsaurus <2098517+lemonsaurus@users.noreply.github.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+"discord.py" = "2.1"
+aiohttp = "^3.8.4"
+aiowowapi = "^2.1.4"
+Pillow = "^9.4.0"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR sets up the basic bot boilerplate.
- It adds a `main.py`, which mostly just loads all the extensions in the `/cogs` folder
- It adds a single cog, `wow.py`, which has a few starter features for working with the WoW API. This is mostly as an example.
- It adds poetry, which is the dependency manager we will be using to keep dependencies in sync across platforms and environments. This is similar to npm for JS.
- It adds a Procfile used by Railway and nixpacks for deployment, to tell it how to run our bot.

The boilerplate has fully modular extension design, and should allow even beginners to whip up new cogs pretty easily. You would just copypaste wow.py, and repurpose that code to serve some other purpose, but with the same basic structure.

Railway will need a few environment variables to run this, and we need to actually set a bot up in the Discord Developers Dashboard and run the auth flow to get it onto the server, but it should be deployable after that.